### PR TITLE
Use `pg_isready` to check the availability of the postgres database before running migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM chatwoot/chatwoot:v2.18.0-ce
 
-ARG FRONTEND_URL ACTIVE_STORAGE_SERVICE DATABASE_URL DEFAULT_LOCALE INSTALLATION_ENV NODE_ENV RAILS_ENV REDIS_URL SECRET_KEY_BASE
+ARG FRONTEND_URL ACTIVE_STORAGE_SERVICE DATABASE_URL PGHOST PGPORT DEFAULT_LOCALE INSTALLATION_ENV NODE_ENV RAILS_ENV REDIS_URL SECRET_KEY_BASE
 
 RUN apk add --no-cache multirun postgresql-client
 
-RUN pg_isready -d $DATABASE_URL && bundle exec rails db:chatwoot_prepare && bundle exec rails db:migrate
+RUN pg_isready -h $PGHOST -p $PGPORT && bundle exec rails db:chatwoot_prepare && bundle exec rails db:migrate
 
 ENTRYPOINT ["multirun"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM chatwoot/chatwoot:v2.18.0-ce
 
 ARG FRONTEND_URL ACTIVE_STORAGE_SERVICE DATABASE_URL DEFAULT_LOCALE INSTALLATION_ENV NODE_ENV RAILS_ENV REDIS_URL SECRET_KEY_BASE
 
-RUN apk add --no-cache multirun
+RUN apk add --no-cache multirun postgresql-client
 
-RUN sleep 3 && bundle exec rails db:chatwoot_prepare && bundle exec rails db:migrate
+RUN pg_isready -d $DATABASE_URL && bundle exec rails db:chatwoot_prepare && bundle exec rails db:migrate
 
 ENTRYPOINT ["multirun"]
 


### PR DESCRIPTION
Replaces a `sleep 3` command